### PR TITLE
Add icons to sensors, refresh radar on type change

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     platform = entity_platform.async_get_current_platform()
 
     platform.async_register_entity_service(
-        SERVICE_SET_RADAR_TYPE, SET_RADAR_TYPE_SCHEMA, "set_radar_type"
+        SERVICE_SET_RADAR_TYPE, SET_RADAR_TYPE_SCHEMA, "async_set_radar_type"
     )
 
 
@@ -96,9 +96,10 @@ class ECCamera(Camera):
         self.image = await self._radar_object.get_loop()
         self.timestamp = self._radar_object.timestamp
 
-    def set_radar_type(self, radar_type):
+    async def async_set_radar_type(self, radar_type):
         """Set the type of radar to display."""
         self._radar_object.precip_type = radar_type.lower()
+        await self.async_update(no_throttle=True)
 
     @property
     def name(self):

--- a/const.py
+++ b/const.py
@@ -163,7 +163,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="humidity",
         name="Humidity",
-        icon="mdi-water-percent",
+        icon="mdi:water-percent",
         device_class=DEVICE_CLASS_HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
         unit_convert=PERCENTAGE,
@@ -187,7 +187,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="wind_bearing",
         name="Wind Bearing",
-        icon="mdi:compass-rose",
+        icon="mdi:compass",
         device_class=None,
         native_unit_of_measurement=DEGREE,
         unit_convert=DEGREE,

--- a/const.py
+++ b/const.py
@@ -115,7 +115,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="dewpoint",
         name="Dew Point",
-        icon=None,
+        icon="mdi:thermometer",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         unit_convert=TEMP_CELSIUS,
@@ -123,7 +123,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="temperature",
         name="Temperature",
-        icon=None,
+        icon="mdi:thermometer",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         unit_convert=TEMP_CELSIUS,
@@ -131,7 +131,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="low_temp",
         name="Low Temperature",
-        icon=None,
+        icon="mdi:thermometer-chevron-down",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         unit_convert=TEMP_CELSIUS,
@@ -139,7 +139,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="high_temp",
         name="High Temperature",
-        icon=None,
+        icon="mdi:thermometer-chevron-up",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         unit_convert=TEMP_CELSIUS,
@@ -147,7 +147,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="wind_chill",
         name="Wind Chill",
-        icon=None,
+        icon="mdi:thermometer-minus",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         unit_convert=TEMP_CELSIUS,
@@ -155,7 +155,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="humidex",
         name="Humidex",
-        icon=None,
+        icon="mdi:thermometer-plus",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
         unit_convert=TEMP_CELSIUS,
@@ -163,7 +163,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="humidity",
         name="Humidity",
-        icon=None,
+        icon="mdi-water-percent",
         device_class=DEVICE_CLASS_HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
         unit_convert=PERCENTAGE,
@@ -195,7 +195,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="pressure",
         name="Barometric Pressure",
-        icon=None,
+        icon="mdi:gauge",
         device_class=DEVICE_CLASS_PRESSURE,
         native_unit_of_measurement=PRESSURE_HPA,
         unit_convert=PRESSURE_INHG,
@@ -203,7 +203,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="visibility",
         name="Visibility",
-        icon="mdi:eye",
+        icon="mdi:telescope",
         device_class=None,
         native_unit_of_measurement=LENGTH_KILOMETERS,
         unit_convert=LENGTH_MILES,
@@ -211,7 +211,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="pop",
         name="Chance of precipitation",
-        icon=None,
+        icon="mdi:weather-snowy-rainy",
         device_class=None,
         native_unit_of_measurement=PERCENTAGE,
         unit_convert=PERCENTAGE,
@@ -219,7 +219,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="precip_yesterday",
         name="Precipitation yesterday",
-        icon=None,
+        icon="mdi:weather-snowy-rainy",
         device_class=None,
         native_unit_of_measurement=LENGTH_MILLIMETERS,
         unit_convert=LENGTH_INCHES,
@@ -227,7 +227,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="uv_index",
         name="UV Index",
-        icon=None,
+        icon="mdi:weather-sunny-alert",
         device_class=None,
         native_unit_of_measurement=UV_INDEX,
         unit_convert=UV_INDEX,
@@ -235,7 +235,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="condition",
         name="Current Condition",
-        icon=None,
+        icon="mdi:weather-partly-snowy-rainy",
         device_class=None,
         native_unit_of_measurement=None,
         unit_convert=None,
@@ -243,7 +243,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="icon_code",
         name="Icon Code",
-        icon=None,
+        icon="mdi:weather-partly-snowy-rainy",
         device_class=None,
         native_unit_of_measurement=None,
         unit_convert=None,
@@ -251,7 +251,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="tendency",
         name="Tendency",
-        icon=None,
+        icon="mdi:swap-vertical",
         device_class=None,
         native_unit_of_measurement=None,
         unit_convert=None,
@@ -259,7 +259,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="text_summary",
         name="Summary",
-        icon=None,
+        icon="mdi:weather-partly-snowy-rainy",
         device_class=None,
         native_unit_of_measurement=None,
         unit_convert=None,
@@ -267,7 +267,7 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
     ECSensorEntityDescription(
         key="wind_dir",
         name="Wind Direction",
-        icon=None,
+        icon="mdi:sign-direction",
         device_class=None,
         native_unit_of_measurement=None,
         unit_convert=None,

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Environment Canada v2",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "codeowners": ["@gwww", "@michaeldavie"],
-  "requirements": ["env_canada==0.5.5"],
+  "requirements": ["env_canada==0.5.6"],
   "quality_scale": "platinum",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/sensor.py
+++ b/sensor.py
@@ -24,11 +24,11 @@ from .const import (
 )
 
 ALERTS = [
-    ("advisories", "Advisory"),
-    ("endings", "Ending"),
-    ("statements", "Statement"),
-    ("warnings", "Warning"),
-    ("watches", "Watch"),
+    ("advisories", "Advisory", "mdi:bell-alert"),
+    ("endings", "Ending", "mdi:alert-circle-check"),
+    ("statements", "Statement", "mdi:bell-alert"),
+    ("warnings", "Warning", "mdi:alert-octagon"),
+    ("watches", "Watch", "mdi:alert"),
 ]
 
 
@@ -146,3 +146,8 @@ class ECAlertSensor(ECBaseEntity, SensorEntity):
         """Return if the entity should be enabled when first added to the entity registry."""
         return True  # FIX ME
         # return False
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._alert_name[2]

--- a/sensor.py
+++ b/sensor.py
@@ -103,6 +103,10 @@ class ECSensor(ECBaseEntity, SensorEntity):
         return True  # FIX ME
         # return False
 
+    @property
+    def icon(self):
+        """Return the icon."""
+        return self._entity_description.icon
 
 class ECAlertSensor(ECBaseEntity, SensorEntity):
     """An EC Sensor Entity for Alerts."""


### PR DESCRIPTION
- Adds icons to condition and alert sensors
- Adds support for `Auto` precipitation type (v0.5.6 of library)
- Refreshes radar when precipitation type set via service